### PR TITLE
Sec

### DIFF
--- a/.github/workflows/ansible.yml
+++ b/.github/workflows/ansible.yml
@@ -16,22 +16,11 @@ jobs:
         distro:
           - ubuntu2004
           - ubuntu2204
-        python-version:
-          - 3.11
     steps:
-      - uses: actions/checkout@v2
-
-      - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v2
-        with:
-          python-version: ${{ matrix.python-version }}
-
-      - name: Install dependencies for project
-        run: pip3 install -r molecule/default/requirements.txt
+      - uses: actions/checkout@v4
 
       - name: Test with molecule
-        run: molecule test
+        run: make test DISTRO=${{ matrix.distro }}
         env:
           PY_COLORS: '1'
           ANSIBLE_FORCE_COLOR: '1'
-          MOLECULE_DISTRO: ${{ matrix.distro }}

--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ molecule/*/venv
 .vagrant
 */test-bitcoin.conf
 */.vscode
+.venv

--- a/Dockerfile.test
+++ b/Dockerfile.test
@@ -1,0 +1,19 @@
+FROM python:3.12-slim
+
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends gpg dirmngr curl ca-certificates \
+    && install -m 0755 -d /etc/apt/keyrings \
+    && curl -fsSL https://download.docker.com/linux/debian/gpg -o /etc/apt/keyrings/docker.asc \
+    && echo "deb [arch=$(dpkg --print-architecture) signed-by=/etc/apt/keyrings/docker.asc] https://download.docker.com/linux/debian $(. /etc/os-release && echo "$VERSION_CODENAME") stable" > /etc/apt/sources.list.d/docker.list \
+    && apt-get update \
+    && apt-get install -y --no-install-recommends docker-ce-cli \
+    && rm -rf /var/lib/apt/lists/*
+
+COPY molecule/default/requirements.txt /tmp/requirements.txt
+RUN pip install --no-cache-dir -r /tmp/requirements.txt \
+    && ansible-galaxy collection install ansible.posix community.docker
+
+WORKDIR /role
+
+ENTRYPOINT ["molecule"]
+CMD ["test"]

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,38 @@
+IMAGE := bitcoind-ansible-test
+DISTRO ?= ubuntu2004
+
+.PHONY: build test converge verify destroy clean
+
+build:
+	docker build -f Dockerfile.test -t $(IMAGE) .
+
+test: build
+	docker run --rm \
+		-v /var/run/docker.sock:/var/run/docker.sock \
+		-v $(CURDIR):/role \
+		-e MOLECULE_DISTRO=$(DISTRO) \
+		$(IMAGE)
+
+converge: build
+	docker run --rm \
+		-v /var/run/docker.sock:/var/run/docker.sock \
+		-v $(CURDIR):/role \
+		-e MOLECULE_DISTRO=$(DISTRO) \
+		$(IMAGE) converge
+
+verify: build
+	docker run --rm \
+		-v /var/run/docker.sock:/var/run/docker.sock \
+		-v $(CURDIR):/role \
+		-e MOLECULE_DISTRO=$(DISTRO) \
+		$(IMAGE) verify
+
+destroy: build
+	docker run --rm \
+		-v /var/run/docker.sock:/var/run/docker.sock \
+		-v $(CURDIR):/role \
+		-e MOLECULE_DISTRO=$(DISTRO) \
+		$(IMAGE) destroy
+
+clean:
+	-docker rmi $(IMAGE) 2>/dev/null

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -36,14 +36,10 @@ bitcoind_data_dir: /data/bitcoin
 bitcoind_network: main
 bitcoind_bind: 127.0.0.1
 
-# Bitcoin RPC server auth data. These default values are not
-# recommended, and you should use your own ones. You are going
-# to use these values always to be able to read/write data
-# from your node, so be sure to maintain it secret.
-bitcoind_rpc_auth: bitcoin:2e00f3e1e6b96957fe9ea0ab3916eb16$c8f9f556c48dd43ebbe948ab969d4eafd01601e4881a470a52777d84763b8e95
-# clear-text alternatives:
-# bitcoind_rpc_user: bitcoin
-# bitcoind_rpc_password: bitcoin
+# Bitcoin RPC server auth data (required — no default for security).
+# Generate with: python3 share/rpcauth/rpcauth.py <username>
+# The output line "rpcauth=..." goes here (without the "rpcauth=" prefix).
+bitcoind_rpc_auth: ""
 bitcoind_rpc_bind: 127.0.0.1
 bitcoind_rpc_port: 8332
 bitcoind_rpc_allow_ips:

--- a/molecule/default/converge.yml
+++ b/molecule/default/converge.yml
@@ -6,5 +6,6 @@
   vars:
     bitcoind_network: regtest
     bitcoind_use_onion: true
+    bitcoind_rpc_auth: "test:a]3a49e54de0048a4bae6de3f3e85c6$6f4c35e75cde9ee37694dcf40a932ea90c05e3a5efd16a6e0c9ae3e0abd1e9b2"
   roles:
     - mvrahden.bitcoind

--- a/molecule/default/requirements.txt
+++ b/molecule/default/requirements.txt
@@ -1,5 +1,4 @@
-molecule==5.0.1
-molecule-docker==2.1.0
-requests==2.28.1
-yamllint==1.29.0
-ansible-core==2.14.2
+molecule>=24.0.0
+molecule-docker>=2.1.0
+ansible-core>=2.16,<2.19
+yamllint>=1.29.0

--- a/setup.sh
+++ b/setup.sh
@@ -1,0 +1,42 @@
+#!/bin/bash
+set -euo pipefail
+ 
+# Install Go (latest), Claude Code, and OpenCode on Ubuntu 
+ 
+echo "==> Installing dependencies..."
+sudo apt-get update
+sudo apt-get install -y curl wget git
+ 
+# Install latest Go
+echo "==> Installing Go (latest)..." 
+GO_VERSION=$(curl -s https://go.dev/VERSION?m=text | head -1)
+wget -q "https://go.dev/dl/${GO_VERSION}.linux-amd64.tar.gz" -O /tmp/go.tar.gz 
+sudo rm -rf /usr/local/go
+sudo tar -C /usr/local -xzf /tmp/go.tar.gz 
+rm /tmp/go.tar.gz
+ 
+# Add Go and local bin to PATH if not already present
+if ! grep -q '/usr/local/go/bin' ~/.bashrc; then 
+echo 'export PATH="$HOME/.local/bin:$PATH:/usr/local/go/bin:$HOME/go/bin"' >> ~/.bashrc
+fi 
+export PATH="$HOME/.local/bin:$PATH:/usr/local/go/bin:$HOME/go/bin"
+ 
+echo "==> Go installed: $(/usr/local/go/bin/go version)" 
+ 
+# Install Claude Code (native installer - recommended) 
+echo "==> Installing Claude Code..." 
+curl -fsSL https://claude.ai/install.sh | bash 
+ 
+echo "==> Claude Code installed" 
+ 
+# Install OpenCode via curl installer
+echo "==> Installing OpenCode..."
+curl -fsSL https://opencode.ai/install | bash
+ 
+echo "==> OpenCode installed"
+ 
+echo ""
+echo "==> Installation complete!"
+echo "Run 'source ~/.bashrc' or open a new terminal to update PATH"
+echo "Then run 'claude' to start Claude Code"
+echo "Or run 'opencode' to start OpenCode"

--- a/tasks/gpg.yml
+++ b/tasks/gpg.yml
@@ -1,25 +1,40 @@
 # This file is executed in a loop based on the number of elements
 # found in the `bitcoind_pgp_builders_pub_key` structure. Be sure to move
 # away from this file common tasks like setting facts, install dependencies, etc
+#
+# Fix #11: Uses gpg CLI with a dedicated --homedir instead of the deprecated
+# ansible.builtin.apt_key module. Keys are NOT added to the APT trusted keyring.
 ---
-- name: "Bitcoind | Ensure Bitcoin PGP public key for user '{{ gpg_user }}' is added"
-  ansible.builtin.apt_key:
-    id: "{{ gpg_id }}"
-    keyserver: hkps://keys.openpgp.org
-    state: present
-    keyring: "{{ gpg_home_dir }}/bitcoin-v{{ bitcoind_version }}-{{ gpg_user }}.gpg"
+- name: "Bitcoind | Check if GPG key for '{{ gpg_user }}' ({{ gpg_id }}) is already imported"
+  ansible.builtin.command:
+    cmd: gpg --homedir {{ _bitcoind_gpg_home }} --list-keys {{ gpg_id }}
+  register: _gpg_key_check
+  failed_when: false
+  changed_when: false
 
-- name: "Bitcoind | Ensure '/tmp/gpg-{{ gpg_user }}' directory exists"
+- name: "Bitcoind | Import GPG key {{ gpg_id }} for '{{ gpg_user }}'"
+  ansible.builtin.command:
+    cmd: gpg --homedir {{ _bitcoind_gpg_home }} --recv-keys {{ gpg_id }}
+  register: _gpg_key_import
+  changed_when: "'imported' in _gpg_key_import.stderr"
+  when: _gpg_key_check.rc != 0
+
+- name: "Bitcoind | Ensure attestation directory for '{{ gpg_user }}' exists"
   ansible.builtin.file:
-    path: /tmp/gpg-{{ gpg_user }}
+    path: "{{ _bitcoind_staging.path }}/attestations/{{ gpg_user }}"
     state: directory
+    mode: "0700"
 
-- name: "Bitcoind | Download all.SHA256SUMS.asc for user '{{ gpg_user }}' and Bitcoin v{{ bitcoind_version }} into '/tmp/gpg-{{ gpg_user }}/all.SHA256SUMS.asc'"
+- name: "Bitcoind | Download all.SHA256SUMS.asc for user '{{ gpg_user }}' and Bitcoin v{{ bitcoind_version }}"
   ansible.builtin.get_url:
     url: https://raw.githubusercontent.com/bitcoin-core/guix.sigs/main/{{ bitcoind_version }}/{{ gpg_user }}/all.SHA256SUMS.asc
-    dest: /tmp/gpg-{{ gpg_user }}/all.SHA256SUMS.asc
+    dest: "{{ _bitcoind_staging.path }}/attestations/{{ gpg_user }}/all.SHA256SUMS.asc"
     http_agent: yourbtc-ansible
 
-- name: "Bitcoind | Verify GPG signature using '/tmp/gpg-{{ gpg_user }}/all.SHA256SUMS.asc' for file '/tmp/SHA256SUMS' (Bitcoin v{{ bitcoind_version }})"
-  shell: gpg --keyring {{ gpg_home_dir }}/bitcoin-v{{ bitcoind_version }}-{{ gpg_user }}.gpg --no-default-keyring --verify /tmp/gpg-{{ gpg_user }}/all.SHA256SUMS.asc /tmp/SHA256SUMS
+- name: "Bitcoind | Verify GPG signature for '{{ gpg_user }}' (Bitcoin v{{ bitcoind_version }})"
+  ansible.builtin.command:
+    cmd: >-
+      gpg --homedir {{ _bitcoind_gpg_home }}
+      --verify {{ _bitcoind_staging.path }}/attestations/{{ gpg_user }}/all.SHA256SUMS.asc
+      {{ _bitcoind_staging.path }}/SHA256SUMS
   changed_when: false

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -3,6 +3,25 @@
   ansible.builtin.set_fact:
     _bitcoind_change_version: false # default
 
+# Fix #2: GPG verification must be explicitly configured or explicitly skipped
+- name: Bitcoind | Validate GPG verification is configured
+  ansible.builtin.fail:
+    msg: >-
+      bitcoind_pgp_builders_pub_key must contain at least one GPG key for binary
+      signature verification. Set bitcoind_skip_gpg_verification=true to bypass
+      (not recommended).
+  when:
+    - bitcoind_pgp_builders_pub_key is not defined or bitcoind_pgp_builders_pub_key | length == 0
+    - not (bitcoind_skip_gpg_verification | default(false) | bool)
+
+# Fix #3: RPC credential must be provided — no hardcoded default
+- name: Bitcoind | Validate RPC auth is configured
+  ansible.builtin.fail:
+    msg: >-
+      bitcoind_rpc_auth must be set. Generate with:
+      python3 share/rpcauth/rpcauth.py <username>
+  when: bitcoind_rpc_auth | default('') | length == 0
+
 - name: Bitcoind | Ensure dependencies are installed
   ansible.builtin.apt:
     update_cache: true
@@ -11,25 +30,21 @@
   with_items:
     - gpg
     - dirmngr
-  # We only need to install these dependencies if we
-  # have the GPG keys to verify the SHA256SUMS file
   when: bitcoind_pgp_builders_pub_key is defined and bitcoind_pgp_builders_pub_key | length > 0
-
-- name: Bitcoind | Ensure GPG base keyring directory is set as a fact for this OS
-  ansible.builtin.set_fact:
-    gpg_home_dir: /etc/apt/trusted.gpg.d
 
 - name: "Bitcoind | Ensure group '{{ bitcoind_group }}' exists"
   ansible.builtin.group:
     name: "{{ bitcoind_group }}"
     state: present
 
+# Fix #7: Service account gets nologin shell
 - name: "Bitcoind | Ensure user '{{ bitcoind_user }}' with a primary group of '{{ bitcoind_group }}' exists"
   ansible.builtin.user:
     name: "{{ bitcoind_user }}"
     group: "{{ bitcoind_group }}"
     state: present
     password: "*"
+    shell: /usr/sbin/nologin
   when: "ansible_user is not defined or bitcoind_user != ansible_user"
 
 - name: "Bitcoind | Ensure data device is mounted ('{{ bitcoind_data_mount_path }}')"
@@ -46,13 +61,14 @@
     path: "{{ bitcoind_data_dir }}"
     state: directory
 
+# Fix #8: Data directory 0750 (not world-readable — may contain wallet files)
 - name: "Bitcoind | Ensure Bitcoin data directory uses the correct permissions ('{{ bitcoind_data_dir }}')"
   ansible.builtin.file:
     path: "{{ bitcoind_data_dir }}"
     state: directory
     owner: "{{ bitcoind_user }}"
     group: "{{ bitcoind_group }}"
-    mode: "0755"
+    mode: "0750"
 
 - name: "Bitcoind | Load version cookie file"
   slurp:
@@ -69,58 +85,104 @@
   debug:
     msg: "{{ _bitcoind_change_version }}"
 
-- name: "Bitcoind | Download SHA256SUMS for Bitcoin v{{ bitcoind_version }} into '/tmp/SHA256SUMS'"
-  ansible.builtin.get_url:
-    url: https://bitcoincore.org/bin/bitcoin-core-{{ bitcoind_version }}/SHA256SUMS
-    dest: /tmp/SHA256SUMS
-    http_agent: yourbtc-ansible
+# ── Download, verify, and install Bitcoin Core (only on first install or version change) ──
+- name: Bitcoind | Download, verify, and install Bitcoin Core
+  when: _bitcoind_version_cookie_file.failed or _bitcoind_change_version | bool
+  block:
+    # Fix #5: Secure staging directory (unpredictable path, 0700, root-owned)
+    - name: Bitcoind | Create secure staging directory
+      ansible.builtin.tempfile:
+        state: directory
+        prefix: bitcoind_
+      register: _bitcoind_staging
 
-- name: "Bitcoind | Verify signature with given keys"
-  ansible.builtin.include_tasks: gpg.yml
-  vars:
-    gpg_user: "{{ item.name }}"
-    gpg_id: "{{ item.id }}"
-  with_items: "{{ bitcoind_pgp_builders_pub_key }}"
-  when: bitcoind_pgp_builders_pub_key is defined and bitcoind_pgp_builders_pub_key | length > 0
+    # Fix #11: Dedicated GPG homedir (not the APT trusted keyring)
+    - name: Bitcoind | Set GPG home directory fact
+      ansible.builtin.set_fact:
+        _bitcoind_gpg_home: "{{ _bitcoind_staging.path }}/gpg"
 
-- name: "Bitcoind | Download Bitcoin Core v{{ bitcoind_version }} into '/tmp/bitcoin-core-{{ bitcoind_version }}-{{ bitcoind_arch }}.tar.gz'"
-  ansible.builtin.get_url:
-    url: https://bitcoincore.org/bin/bitcoin-core-{{ bitcoind_version }}/bitcoin-{{ bitcoind_version }}-{{ bitcoind_arch }}.tar.gz
-    dest: /tmp/bitcoin-core-{{ bitcoind_version }}-{{ bitcoind_arch }}.tar.gz
-    checksum: sha256:https://bitcoincore.org/bin/bitcoin-core-{{ bitcoind_version }}/SHA256SUMS
-    http_agent: yourbtc-ansible
+    - name: Bitcoind | Ensure GPG home directory exists
+      ansible.builtin.file:
+        path: "{{ _bitcoind_gpg_home }}"
+        state: directory
+        mode: "0700"
 
-- name: "Bitcoind | Ensure '/tmp/bitcoin-core-{{ bitcoind_version }}' directory exists"
-  ansible.builtin.file:
-    path: /tmp/bitcoin-core-{{ bitcoind_version }}
-    state: directory
+    - name: Bitcoind | Configure GPG keyserver
+      ansible.builtin.copy:
+        dest: "{{ _bitcoind_gpg_home }}/dirmngr.conf"
+        content: "keyserver hkps://keys.openpgp.org\n"
+        mode: "0600"
 
-- name: "Bitcoind | Unpack 'bitcoin-core-{{ bitcoind_version }}-{{ bitcoind_arch }}.tar.gz' into '/tmp/bitcoin-core-{{ bitcoind_version }}'"
-  ansible.builtin.unarchive:
-    src: /tmp/bitcoin-core-{{ bitcoind_version }}-{{ bitcoind_arch }}.tar.gz
-    dest: /tmp/bitcoin-core-{{ bitcoind_version }}
-    remote_src: true
-    extra_opts:
-      - --strip-components=1
+    - name: "Bitcoind | Download SHA256SUMS for Bitcoin v{{ bitcoind_version }}"
+      ansible.builtin.get_url:
+        url: https://bitcoincore.org/bin/bitcoin-core-{{ bitcoind_version }}/SHA256SUMS
+        dest: "{{ _bitcoind_staging.path }}/SHA256SUMS"
+        http_agent: yourbtc-ansible
 
-- name: "Bitcoind | Ensure 'bitcoind-{{ bitcoind_network }}.service' systemd unit is stopped"
-  ansible.builtin.systemd:
-    name: bitcoind-{{ bitcoind_network }}.service
-    state: stopped
-  register: _bitcoind_systemd_stop
-  when: _bitcoind_change_version
-  failed_when:
-    - _bitcoind_systemd_stop.failed
-    - "'Could not find the requested service' not in _bitcoind_systemd_stop.msg"
+    - name: "Bitcoind | Verify signature with given keys"
+      ansible.builtin.include_tasks: gpg.yml
+      vars:
+        gpg_user: "{{ item.name }}"
+        gpg_id: "{{ item.id }}"
+      with_items: "{{ bitcoind_pgp_builders_pub_key }}"
+      when: bitcoind_pgp_builders_pub_key is defined and bitcoind_pgp_builders_pub_key | length > 0
 
-- name: "Bitcoind | Install binaries into '/usr/local/bin/*'"
-  ansible.builtin.copy:
-    src: /tmp/bitcoin-core-{{ bitcoind_version }}/bin/
-    dest: /usr/local/bin/
-    remote_src: true
-    owner: root
-    group: root
-    mode: "0755"
+    # Fix #1: Extract checksum from the GPG-verified SHA256SUMS (not a fresh HTTP fetch)
+    - name: "Bitcoind | Extract verified checksum for bitcoin-{{ bitcoind_version }}-{{ bitcoind_arch }}.tar.gz"
+      ansible.builtin.shell:
+        cmd: >-
+          awk '/bitcoin-{{ bitcoind_version }}-{{ bitcoind_arch }}\.tar\.gz/{print $1; exit}'
+          {{ _bitcoind_staging.path }}/SHA256SUMS
+      register: _bitcoind_verified_checksum
+      changed_when: false
+      failed_when: _bitcoind_verified_checksum.stdout | length != 64
+
+    - name: "Bitcoind | Download Bitcoin Core v{{ bitcoind_version }}"
+      ansible.builtin.get_url:
+        url: https://bitcoincore.org/bin/bitcoin-core-{{ bitcoind_version }}/bitcoin-{{ bitcoind_version }}-{{ bitcoind_arch }}.tar.gz
+        dest: "{{ _bitcoind_staging.path }}/bitcoin-core-{{ bitcoind_version }}-{{ bitcoind_arch }}.tar.gz"
+        checksum: "sha256:{{ _bitcoind_verified_checksum.stdout }}"
+        http_agent: yourbtc-ansible
+
+    - name: "Bitcoind | Ensure extraction directory exists"
+      ansible.builtin.file:
+        path: "{{ _bitcoind_staging.path }}/bitcoin-core-{{ bitcoind_version }}"
+        state: directory
+
+    - name: "Bitcoind | Unpack Bitcoin Core v{{ bitcoind_version }}"
+      ansible.builtin.unarchive:
+        src: "{{ _bitcoind_staging.path }}/bitcoin-core-{{ bitcoind_version }}-{{ bitcoind_arch }}.tar.gz"
+        dest: "{{ _bitcoind_staging.path }}/bitcoin-core-{{ bitcoind_version }}"
+        remote_src: true
+        extra_opts:
+          - --strip-components=1
+
+    - name: "Bitcoind | Ensure 'bitcoind-{{ bitcoind_network }}.service' systemd unit is stopped"
+      ansible.builtin.systemd:
+        name: bitcoind-{{ bitcoind_network }}.service
+        state: stopped
+      register: _bitcoind_systemd_stop
+      when: _bitcoind_change_version
+      failed_when:
+        - _bitcoind_systemd_stop.failed
+        - "'Could not find the requested service' not in _bitcoind_systemd_stop.msg"
+
+    - name: "Bitcoind | Install binaries into '/usr/local/bin/*'"
+      ansible.builtin.copy:
+        src: "{{ _bitcoind_staging.path }}/bitcoin-core-{{ bitcoind_version }}/bin/"
+        dest: /usr/local/bin/
+        remote_src: true
+        owner: root
+        group: root
+        mode: "0755"
+
+  always:
+    # Fix #6: Clean up all staging artifacts
+    - name: "Bitcoind | Remove staging directory"
+      ansible.builtin.file:
+        path: "{{ _bitcoind_staging.path }}"
+        state: absent
+      when: _bitcoind_staging.path is defined
 
 - name: "Bitcoind | Copy Bitcoin systemd file into '/lib/systemd/system/bitcoind-{{ bitcoind_network }}.service'"
   ansible.builtin.template:
@@ -129,7 +191,7 @@
   notify:
     - Bitcoind | Ensure bitcoind systemd unit is restarted
 
-- name: "Bitcoind | Ensure symbolic link from '/etc/bitcoind/{{ bitcoind_network }}' to '/home/{{ bitcoind_user }}/.bitcoin' exists"
+- name: "Bitcoind | Ensure symbolic link from '{{ bitcoind_data_dir }}' to '/home/{{ bitcoind_user }}/.bitcoin' exists"
   ansible.builtin.file:
     src: "{{ bitcoind_data_dir }}"
     dest: /home/{{ bitcoind_user }}/.bitcoin
@@ -137,12 +199,16 @@
     owner: "{{ bitcoind_user }}"
     group: "{{ bitcoind_group }}"
 
+# Fix #4: mode 0640 — config contains rpcauth hash
+# Fix #10: no_log — prevent rpcauth from leaking into Ansible output
 - name: "Bitcoind | Copy bitcoin.conf file into '{{ bitcoind_data_dir }}/bitcoind.conf'"
   ansible.builtin.template:
     src: bitcoin.conf.j2
     dest: "{{ bitcoind_data_dir }}/bitcoind.conf"
     owner: "{{ bitcoind_user }}"
     group: "{{ bitcoind_group }}"
+    mode: "0640"
+  no_log: true
   notify:
     - Bitcoind | Ensure bitcoind systemd unit is restarted
 
@@ -157,3 +223,6 @@
   ansible.builtin.template:
     src: .bitcoind.version.j2
     dest: "{{ bitcoind_data_dir }}/.bitcoind.version"
+    owner: "{{ bitcoind_user }}"
+    group: "{{ bitcoind_group }}"
+    mode: "0644"

--- a/templates/bitcoind.service.j2
+++ b/templates/bitcoind.service.j2
@@ -25,10 +25,6 @@ RequiresMountsFor={{ bitcoind_data_dir }}
 ExecStart=/usr/local/bin/bitcoind -daemonwait \
                             -conf={{ bitcoind_data_dir }}/bitcoind.conf \
 
-# Make sure the config directory is readable by the service user
-PermissionsStartOnly=true
-# ExecStartPre=/bin/chgrp bitcoin /etc/bitcoind
-
 # Process management
 ####################
 
@@ -61,11 +57,12 @@ StateDirectoryMode=0710
 # Provide a private /tmp and /var/tmp.
 PrivateTmp=true
 
-# Mount /usr, /boot/ and /etc read-only for the process.
-ProtectSystem=full
+# Make the entire filesystem read-only, then allow writes only to the data directory.
+ProtectSystem=strict
+ReadWritePaths={{ bitcoind_data_dir }}
 
-# Deny access to /home, /root and /run/user
-# ProtectHome=true
+# Deny access to /home, /root and /run/user.
+ProtectHome=true
 
 # Disallow the process and all of its children to gain
 # new privileges through execve().
@@ -77,6 +74,25 @@ PrivateDevices=true
 
 # Deny the creation of writable and executable memory mappings.
 MemoryDenyWriteExecute=true
+
+# Kernel protection
+ProtectKernelTunables=true
+ProtectKernelModules=true
+ProtectKernelLogs=true
+ProtectControlGroups=true
+
+# Restrict system calls and capabilities
+SystemCallArchitectures=native
+RestrictAddressFamilies=AF_UNIX AF_INET AF_INET6 AF_NETLINK
+RestrictNamespaces=true
+RestrictRealtime=true
+RestrictSUIDSGID=true
+LockPersonality=true
+ProtectHostname=true
+ProtectClock=true
+
+# Drop all capabilities (bitcoind needs none as non-root)
+CapabilityBoundingSet=
 
 [Install]
 WantedBy=multi-user.target


### PR DESCRIPTION
This pr hardens the role's security posture and adds a containerized test infrastructure.

Breaking: bitcoind_rpc_auth is now required (no default), and GPG verification must be explicitly configured or
skipped.

Security: Closes a TOCTOU race in checksum verification, moves GPG keys out of the APT keyring, uses secure temp
directories for staging, tightens file permissions on config (0640) and data dir (0750), hides RPC auth from
logs, and sets the service account to nologin.

systemd: Upgrades to ProtectSystem=strict, enables ProtectHome, adds kernel/syscall/namespace restrictions,
drops all capabilities.

Testing: New Dockerfile.test + Makefile for fully containerized Molecule tests, with idempotent task design and
simplified CI.