### PR TITLE
Bump to v30.2

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -4,7 +4,7 @@ bitcoind_user: bitcoin
 bitcoind_group: bitcoin
 
 # Bitcoin binary information
-bitcoind_version: 29.0
+bitcoind_version: 30.2
 bitcoind_arch: x86_64-linux-gnu
 
 # Serve JOSN-RPC

--- a/molecule/default/verify.yml
+++ b/molecule/default/verify.yml
@@ -4,7 +4,7 @@
   become: true
   gather_facts: false
   vars:
-    bitcoind_version: 29.0
+    bitcoind_version: 30.2
 
   tasks:
     - name: "Retrieve information from /usr/local/bin/*"
@@ -12,13 +12,13 @@
         path: "/usr/local/bin/{{ item }}"
       register: bitcoind_bins
       with_items:
+        - bitcoin
         - bitcoin-cli
         - bitcoin-qt
         - bitcoin-tx
         - bitcoin-util
         - bitcoin-wallet
         - bitcoind
-        - test_bitcoin
 
     - name: "Test that binaries were copied correctly for Bitcoin Core v{{ bitcoind_version }}"
       ansible.builtin.assert:

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -177,6 +177,15 @@
         mode: "0755"
 
   always:
+    # gpg-agent creates socket files (S.gpg-agent*) that vanish asynchronously
+    # on shutdown, causing rmtree ENOENT races. Kill it first.
+    - name: "Bitcoind | Stop gpg-agent for staging cleanup"
+      ansible.builtin.command:
+        cmd: gpgconf --homedir {{ _bitcoind_gpg_home }} --kill gpg-agent
+      failed_when: false
+      changed_when: false
+      when: _bitcoind_gpg_home is defined
+
     # Fix #6: Clean up all staging artifacts
     - name: "Bitcoind | Remove staging directory"
       ansible.builtin.file:


### PR DESCRIPTION
- Bump default version from 29.0 to 30.2
- Update verify.yml binary list: replace test_bitcoin (moved to libexec/) with new bitcoin wrapper binary
- Kill gpg-agent before staging cleanup to prevent rmtree ENOENT race on socket files (S.gpg-agent*)