### PR TITLE
update README

### DIFF
--- a/.github/workflows/ansible.yml
+++ b/.github/workflows/ansible.yml
@@ -13,14 +13,21 @@ jobs:
     strategy:
       max-parallel: 4
       matrix:
-        distro:
-          - ubuntu2004
-          - ubuntu2204
+        include:
+          - distro: ubuntu2004
+            impl: core
+            version: "30.2"
+          - distro: ubuntu2204
+            impl: core
+            version: "30.2"
+          - distro: ubuntu2204
+            impl: knots
+            version: "29.2.knots20251110"
     steps:
       - uses: actions/checkout@v4
 
       - name: Test with molecule
-        run: make test DISTRO=${{ matrix.distro }}
+        run: make test DISTRO=${{ matrix.distro }} BITCOIND_IMPL=${{ matrix.impl }} BITCOIND_VERSION=${{ matrix.version }}
         env:
           PY_COLORS: '1'
           ANSIBLE_FORCE_COLOR: '1'

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,7 @@
 IMAGE := bitcoind-ansible-test
 DISTRO ?= ubuntu2004
+BITCOIND_IMPL ?= core
+BITCOIND_VERSION ?=
 
 .PHONY: build test converge verify destroy clean
 
@@ -11,6 +13,8 @@ test: build
 		-v /var/run/docker.sock:/var/run/docker.sock \
 		-v $(CURDIR):/role \
 		-e MOLECULE_DISTRO=$(DISTRO) \
+		-e BITCOIND_IMPL=$(BITCOIND_IMPL) \
+		-e BITCOIND_VERSION=$(BITCOIND_VERSION) \
 		$(IMAGE)
 
 converge: build
@@ -18,6 +22,8 @@ converge: build
 		-v /var/run/docker.sock:/var/run/docker.sock \
 		-v $(CURDIR):/role \
 		-e MOLECULE_DISTRO=$(DISTRO) \
+		-e BITCOIND_IMPL=$(BITCOIND_IMPL) \
+		-e BITCOIND_VERSION=$(BITCOIND_VERSION) \
 		$(IMAGE) converge
 
 verify: build
@@ -25,6 +31,8 @@ verify: build
 		-v /var/run/docker.sock:/var/run/docker.sock \
 		-v $(CURDIR):/role \
 		-e MOLECULE_DISTRO=$(DISTRO) \
+		-e BITCOIND_IMPL=$(BITCOIND_IMPL) \
+		-e BITCOIND_VERSION=$(BITCOIND_VERSION) \
 		$(IMAGE) verify
 
 destroy: build
@@ -32,6 +40,8 @@ destroy: build
 		-v /var/run/docker.sock:/var/run/docker.sock \
 		-v $(CURDIR):/role \
 		-e MOLECULE_DISTRO=$(DISTRO) \
+		-e BITCOIND_IMPL=$(BITCOIND_IMPL) \
+		-e BITCOIND_VERSION=$(BITCOIND_VERSION) \
 		$(IMAGE) destroy
 
 clean:

--- a/README.md
+++ b/README.md
@@ -1,14 +1,14 @@
-# Bitcoin Core Ansible role
+# Bitcoin Core / Knots Ansible role
 
 ![GitHub Workflow Status (with branch)](https://img.shields.io/github/actions/workflow/status/mvrahden/bitcoind-ansible/ansible.yml?branch=main&label=Ansible%20Tests&logo=github&style=for-the-badge)
 
-Ansible role to install the [Bitcoin Core](https://bitcoincore.org/en/about/) client as a `systemd` service. By default,
+Ansible role to install [Bitcoin Core](https://bitcoincore.org/en/about/) or [Bitcoin Knots](https://bitcoinknots.org/) as a `systemd` service. By default,
 it uses sane defaults and some hardening measures for the Systemd service.
 
 ## Summary: What does it do?
 
 - Sets up user, if not single user system
-- Downloads bitcoin core and verifies signatures
+- Downloads bitcoin binaries and verifies GPG signatures
 - Installs all shipped binaries to `/usr/local/bin` (i.e. `bitcoin-cli`, `bitcoind`, ...)
 - Sets up a systemd service with configuration at `/etc/bitcoind/<network>/bitcoind.conf`
 - Links `/home/<user>/.bitcoin` to `/etc/bitcoind/<network>`
@@ -26,13 +26,25 @@ List of officially supported operating systems:
 
 ## How to run this?
 
-Create a playbook like this one:
+### Bitcoin Core (default)
 
 ```yaml
 - hosts: bitcoind
+  become: yes
   roles:
     - role: mvrahden.bitcoind
-      become: yes
+```
+
+### Bitcoin Knots
+
+```yaml
+- hosts: bitcoind
+  become: yes
+  vars:
+    bitcoind_implementation: knots
+    bitcoind_version: "29.2.knots20251110"
+  roles:
+    - role: mvrahden.bitcoind
 ```
 
 Note that you can use `become` at a global level instead at the role level.
@@ -53,10 +65,11 @@ You can execute tests using `molecule`. Install the [`requirements.txt`](molecul
 to execute tests through Docker or with a VM managed by Vagrant.
 
 ```bash
-molecule test
+make test                                                              # Core (default)
+BITCOIND_IMPL=knots BITCOIND_VERSION=29.2.knots20251110 make test      # Knots
 ```
 
-If you want to run a test through a specific operating system you can update the `MOLECULE_DISTRO` variable using
+If you want to run a test through a specific operating system you can update the `DISTRO` variable using
 the operating system ID mentioned in the requirements table.
 
 ### Variables
@@ -64,18 +77,19 @@ the operating system ID mentioned in the requirements table.
 You can change some variables to install this role to fit your needs. The default values to install the
 Bitcoin node are the following ones:
 
-| Name               | Value              |
-| ------------------ | ------------------ |
-| `bitcoind_user`    | `bitcoin`          |
-| `bitcoind_group`   | `bitcoin`          |
-| `bitcoind_version` | `29.0`             |
-| `bitcoind_arch`    | `x86_64-linux-gnu` |
+| Name                      | Value              | Note                                    |
+| ------------------------- | ------------------ | --------------------------------------- |
+| `bitcoind_implementation` | `core`             | `core` or `knots`                       |
+| `bitcoind_version`        | `30.2`             | Knots example: `29.2.knots20251110`     |
+| `bitcoind_user`           | `bitcoin`          |                                         |
+| `bitcoind_group`          | `bitcoin`          |                                         |
+| `bitcoind_arch`           | `x86_64-linux-gnu` | Use `aarch64-linux-gnu` for Raspberry Pi|
 
 > If you want to install Bitcoin into a Raspberry you need to change the architecture to `aarch64-linux-gnu`.
 
 To configure the Bitcoin node, you can use the following variables:
 
-> Use [rpcauth.yp](https://raw.githubusercontent.com/bitcoin/bitcoin/master/share/rpcauth/rpcauth.py) to
+> Use [rpcauth.py](https://raw.githubusercontent.com/bitcoin/bitcoin/master/share/rpcauth/rpcauth.py) to
 > generate `rpcauth` credentials.
 
 | Name                     | Value                      | Note                                                 |
@@ -95,23 +109,32 @@ To configure the Bitcoin node, you can use the following variables:
 
 ### GPG verification
 
-By default, this installer uses `gpg` to verify the integrity and signature of the downloaded artifacts. This
-behaviour is controlled by the `bitcoind_pgp_builders_pub_key` field. The content of this structure and default values
-are the following:
+By default, this installer uses `gpg` to verify the integrity and signature of the downloaded artifacts.
+The role selects the appropriate GPG builder keys based on `bitcoind_implementation`.
+
+**Bitcoin Core** default keys (`bitcoind_pgp_builders_pub_key_core`):
 
 | Name       | ID                                         |
 | ---------- | ------------------------------------------ |
 | `laanwj`   | `71A3B16735405025D447E8F274810B012346C9A6` |
 | `fanquake` | `E777299FC265DD04793070EB944D35F9AC3DB76A` |
 
-If you only want to verify with one user, you should use something like this:
+**Bitcoin Knots** default keys (`bitcoind_pgp_builders_pub_key_knots`):
+
+| Name      | ID                                         |
+| --------- | ------------------------------------------ |
+| `luke-jr` | `1A3E761F19D2CC7785C5502EA291A2C45D0C504A` |
+| `shiny`   | `1D70CBE4B42239445617D33DD316C8140185B647` |
+
+If you only want to verify with one user, you can override the list for the respective implementation:
 
 ```yaml
-bitcoind_pgp_builders_pub_key:
+bitcoind_pgp_builders_pub_key_core:
   - id: 71A3B16735405025D447E8F274810B012346C9A6
     name: laanwj
 ```
 
-> I use the Guix attestations to verify the release. The data can be found on
-> the [Bitcoin Github official repository](https://github.com/bitcoin-core/guix.sigs).
+> Guix attestations are used to verify each release. The data can be found in the
+> [Bitcoin Core](https://github.com/bitcoin-core/guix.sigs) or
+> [Bitcoin Knots](https://github.com/bitcoinknots/guix.sigs) guix.sigs repositories.
 > If the release can't be trusted the role will fail the installation.

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -28,7 +28,7 @@ bitcoind_pgp_builders_pub_key_core:
     name: fanquake
 
 bitcoind_pgp_builders_pub_key_knots:
-  - id: 93CB4961F69A65082D4410802CBA8253089655C3
+  - id: 1A3E761F19D2CC7785C5502EA291A2C45D0C504A
     name: luke-jr
   - id: 1D70CBE4B42239445617D33DD316C8140185B647
     name: shiny

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -3,7 +3,11 @@
 bitcoind_user: bitcoin
 bitcoind_group: bitcoin
 
+# Implementation: "core" (Bitcoin Core) or "knots" (Bitcoin Knots)
+bitcoind_implementation: core
+
 # Bitcoin binary information
+# Core default: 30.2  |  Knots example: 29.2.knots20251110
 bitcoind_version: 30.2
 bitcoind_arch: x86_64-linux-gnu
 
@@ -13,14 +17,21 @@ bitcoind_server: true
 # Wallet
 bitcoind_disablewallet: false
 
-# Bitcoin GPG public keys. Name must match the ones found in
-# this link https://github.com/bitcoin-core/guix.sigs. The ID of each
-# user can be found here https://github.com/bitcoin/bitcoin/blob/23.x/contrib/builder-keys/keys.txt
-bitcoind_pgp_builders_pub_key:
+# Bitcoin GPG public keys per implementation.
+# Names must match the ones found in the respective guix.sigs repositories:
+#   Core: https://github.com/bitcoin-core/guix.sigs
+#   Knots: https://github.com/bitcoinknots/guix.sigs
+bitcoind_pgp_builders_pub_key_core:
   - id: 71A3B16735405025D447E8F274810B012346C9A6
     name: laanwj
   - id: E777299FC265DD04793070EB944D35F9AC3DB76A
     name: fanquake
+
+bitcoind_pgp_builders_pub_key_knots:
+  - id: 93CB4961F69A65082D4410802CBA8253089655C3
+    name: luke-jr
+  - id: 1D70CBE4B42239445617D33DD316C8140185B647
+    name: shiny
 
 # Data directory mount configuration.
 # Set bitcoind_data_mount_device to have the role manage the fstab entry.

--- a/molecule/default/converge.yml
+++ b/molecule/default/converge.yml
@@ -7,5 +7,7 @@
     bitcoind_network: regtest
     bitcoind_use_onion: true
     bitcoind_rpc_auth: "test:a]3a49e54de0048a4bae6de3f3e85c6$6f4c35e75cde9ee37694dcf40a932ea90c05e3a5efd16a6e0c9ae3e0abd1e9b2"
+    bitcoind_implementation: "{{ lookup('env', 'BITCOIND_IMPL') | default('core', true) }}"
+    bitcoind_version: "{{ lookup('env', 'BITCOIND_VERSION') | default('30.2', true) }}"
   roles:
     - mvrahden.bitcoind

--- a/molecule/default/molecule.yml
+++ b/molecule/default/molecule.yml
@@ -19,6 +19,8 @@ provisioner:
   name: ansible
   env:
     ANSIBLE_VERBOSITY: 3
+    BITCOIND_IMPL: ${BITCOIND_IMPL:-core}
+    BITCOIND_VERSION: ${BITCOIND_VERSION:-""}
 
 verifier:
   name: ansible

--- a/molecule/default/verify.yml
+++ b/molecule/default/verify.yml
@@ -5,22 +5,34 @@
   gather_facts: false
   vars:
     bitcoind_version: 30.2
+    bitcoind_implementation: core
+    # Core 30.x: bitcoin wrapper replaces test_bitcoin
+    # Knots 29.x: still has test_bitcoin, no bitcoin wrapper
+    _core_binaries:
+      - bitcoin
+      - bitcoin-cli
+      - bitcoin-qt
+      - bitcoin-tx
+      - bitcoin-util
+      - bitcoin-wallet
+      - bitcoind
+    _knots_binaries:
+      - bitcoin-cli
+      - bitcoin-qt
+      - bitcoin-tx
+      - bitcoin-util
+      - bitcoin-wallet
+      - bitcoind
+      - test_bitcoin
 
   tasks:
     - name: "Retrieve information from /usr/local/bin/*"
       ansible.builtin.stat:
         path: "/usr/local/bin/{{ item }}"
       register: bitcoind_bins
-      with_items:
-        - bitcoin
-        - bitcoin-cli
-        - bitcoin-qt
-        - bitcoin-tx
-        - bitcoin-util
-        - bitcoin-wallet
-        - bitcoind
+      with_items: "{{ _core_binaries if bitcoind_implementation == 'core' else _knots_binaries }}"
 
-    - name: "Test that binaries were copied correctly for Bitcoin Core v{{ bitcoind_version }}"
+    - name: "Test that binaries were copied correctly for Bitcoin v{{ bitcoind_version }}"
       ansible.builtin.assert:
         that:
           - item.stat.exists

--- a/molecule/default/verify.yml
+++ b/molecule/default/verify.yml
@@ -4,8 +4,8 @@
   become: true
   gather_facts: false
   vars:
-    bitcoind_version: 30.2
-    bitcoind_implementation: core
+    bitcoind_implementation: "{{ lookup('env', 'BITCOIND_IMPL') | default('core', true) }}"
+    bitcoind_version: "{{ lookup('env', 'BITCOIND_VERSION') | default('30.2', true) }}"
     # Core 30.x: bitcoin wrapper replaces test_bitcoin
     # Knots 29.x: still has test_bitcoin, no bitcoin wrapper
     _core_binaries:

--- a/tasks/gpg.yml
+++ b/tasks/gpg.yml
@@ -1,5 +1,5 @@
 # This file is executed in a loop based on the number of elements
-# found in the `bitcoind_pgp_builders_pub_key` structure. Be sure to move
+# found in the `_bitcoind_pgp_builders` structure. Be sure to move
 # away from this file common tasks like setting facts, install dependencies, etc
 #
 # Fix #11: Uses gpg CLI with a dedicated --homedir instead of the deprecated
@@ -27,7 +27,7 @@
 
 - name: "Bitcoind | Download all.SHA256SUMS.asc for user '{{ gpg_user }}' and Bitcoin v{{ bitcoind_version }}"
   ansible.builtin.get_url:
-    url: https://raw.githubusercontent.com/bitcoin-core/guix.sigs/main/{{ bitcoind_version }}/{{ gpg_user }}/all.SHA256SUMS.asc
+    url: "{{ _bitcoind_guix_sigs_base_url }}/{{ bitcoind_version }}/{{ gpg_user }}/all.SHA256SUMS.asc"
     dest: "{{ _bitcoind_staging.path }}/attestations/{{ gpg_user }}/all.SHA256SUMS.asc"
     http_agent: yourbtc-ansible
 

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -3,15 +3,36 @@
   ansible.builtin.set_fact:
     _bitcoind_change_version: false # default
 
+- name: Bitcoind | Validate implementation is supported
+  ansible.builtin.fail:
+    msg: >-
+      bitcoind_implementation must be "core" or "knots", got "{{ bitcoind_implementation }}".
+  when: bitcoind_implementation not in ['core', 'knots']
+
+- name: Bitcoind | Set implementation-specific facts
+  ansible.builtin.set_fact:
+    _bitcoind_pgp_builders: >-
+      {{ bitcoind_pgp_builders_pub_key_core
+         if bitcoind_implementation == 'core'
+         else bitcoind_pgp_builders_pub_key_knots }}
+    _bitcoind_base_url: >-
+      {{ 'https://bitcoincore.org/bin/bitcoin-core-' ~ bitcoind_version
+         if bitcoind_implementation == 'core'
+         else 'https://bitcoinknots.org/files/' ~ bitcoind_version.split('.')[0] ~ '.x/' ~ bitcoind_version }}
+    _bitcoind_guix_sigs_base_url: >-
+      {{ 'https://raw.githubusercontent.com/bitcoin-core/guix.sigs/main'
+         if bitcoind_implementation == 'core'
+         else 'https://raw.githubusercontent.com/bitcoinknots/guix.sigs/knots' }}
+
 # Fix #2: GPG verification must be explicitly configured or explicitly skipped
 - name: Bitcoind | Validate GPG verification is configured
   ansible.builtin.fail:
     msg: >-
-      bitcoind_pgp_builders_pub_key must contain at least one GPG key for binary
+      GPG builder keys must contain at least one GPG key for binary
       signature verification. Set bitcoind_skip_gpg_verification=true to bypass
       (not recommended).
   when:
-    - bitcoind_pgp_builders_pub_key is not defined or bitcoind_pgp_builders_pub_key | length == 0
+    - _bitcoind_pgp_builders | length == 0
     - not (bitcoind_skip_gpg_verification | default(false) | bool)
 
 # Fix #3: RPC credential must be provided — no hardcoded default
@@ -30,7 +51,7 @@
   with_items:
     - gpg
     - dirmngr
-  when: bitcoind_pgp_builders_pub_key is defined and bitcoind_pgp_builders_pub_key | length > 0
+  when: _bitcoind_pgp_builders | length > 0
 
 - name: "Bitcoind | Ensure group '{{ bitcoind_group }}' exists"
   ansible.builtin.group:
@@ -78,15 +99,15 @@
 
 - name: "Bitcoind | Determine version change from version cookie vs. configured version"
   set_fact:
-    _bitcoind_change_version: "{{ _bitcoind_version_cookie_file['content'] | b64decode | regex_findall('(\\d+\\.\\d+)') | first is version(bitcoind_version, '!=' , strict=true)}}"
+    _bitcoind_change_version: "{{ (_bitcoind_version_cookie_file['content'] | b64decode | trim | split('\n') | last) != (bitcoind_version | string) }}"
   when: "not _bitcoind_version_cookie_file.failed"
 
 - name: "Bitcoind | Debug detected version change from cookie"
   debug:
     msg: "{{ _bitcoind_change_version }}"
 
-# ── Download, verify, and install Bitcoin Core (only on first install or version change) ──
-- name: Bitcoind | Download, verify, and install Bitcoin Core
+# ── Download, verify, and install Bitcoin (only on first install or version change) ──
+- name: Bitcoind | Download, verify, and install Bitcoin
   when: _bitcoind_version_cookie_file.failed or _bitcoind_change_version | bool
   block:
     # Fix #5: Secure staging directory (unpredictable path, 0700, root-owned)
@@ -115,7 +136,7 @@
 
     - name: "Bitcoind | Download SHA256SUMS for Bitcoin v{{ bitcoind_version }}"
       ansible.builtin.get_url:
-        url: https://bitcoincore.org/bin/bitcoin-core-{{ bitcoind_version }}/SHA256SUMS
+        url: "{{ _bitcoind_base_url }}/SHA256SUMS"
         dest: "{{ _bitcoind_staging.path }}/SHA256SUMS"
         http_agent: yourbtc-ansible
 
@@ -124,8 +145,8 @@
       vars:
         gpg_user: "{{ item.name }}"
         gpg_id: "{{ item.id }}"
-      with_items: "{{ bitcoind_pgp_builders_pub_key }}"
-      when: bitcoind_pgp_builders_pub_key is defined and bitcoind_pgp_builders_pub_key | length > 0
+      with_items: "{{ _bitcoind_pgp_builders }}"
+      when: _bitcoind_pgp_builders | length > 0
 
     # Fix #1: Extract checksum from the GPG-verified SHA256SUMS (not a fresh HTTP fetch)
     - name: "Bitcoind | Extract verified checksum for bitcoin-{{ bitcoind_version }}-{{ bitcoind_arch }}.tar.gz"
@@ -137,22 +158,22 @@
       changed_when: false
       failed_when: _bitcoind_verified_checksum.stdout | length != 64
 
-    - name: "Bitcoind | Download Bitcoin Core v{{ bitcoind_version }}"
+    - name: "Bitcoind | Download Bitcoin v{{ bitcoind_version }}"
       ansible.builtin.get_url:
-        url: https://bitcoincore.org/bin/bitcoin-core-{{ bitcoind_version }}/bitcoin-{{ bitcoind_version }}-{{ bitcoind_arch }}.tar.gz
-        dest: "{{ _bitcoind_staging.path }}/bitcoin-core-{{ bitcoind_version }}-{{ bitcoind_arch }}.tar.gz"
+        url: "{{ _bitcoind_base_url }}/bitcoin-{{ bitcoind_version }}-{{ bitcoind_arch }}.tar.gz"
+        dest: "{{ _bitcoind_staging.path }}/bitcoin-{{ bitcoind_version }}-{{ bitcoind_arch }}.tar.gz"
         checksum: "sha256:{{ _bitcoind_verified_checksum.stdout }}"
         http_agent: yourbtc-ansible
 
     - name: "Bitcoind | Ensure extraction directory exists"
       ansible.builtin.file:
-        path: "{{ _bitcoind_staging.path }}/bitcoin-core-{{ bitcoind_version }}"
+        path: "{{ _bitcoind_staging.path }}/bitcoin-{{ bitcoind_version }}"
         state: directory
 
-    - name: "Bitcoind | Unpack Bitcoin Core v{{ bitcoind_version }}"
+    - name: "Bitcoind | Unpack Bitcoin v{{ bitcoind_version }}"
       ansible.builtin.unarchive:
-        src: "{{ _bitcoind_staging.path }}/bitcoin-core-{{ bitcoind_version }}-{{ bitcoind_arch }}.tar.gz"
-        dest: "{{ _bitcoind_staging.path }}/bitcoin-core-{{ bitcoind_version }}"
+        src: "{{ _bitcoind_staging.path }}/bitcoin-{{ bitcoind_version }}-{{ bitcoind_arch }}.tar.gz"
+        dest: "{{ _bitcoind_staging.path }}/bitcoin-{{ bitcoind_version }}"
         remote_src: true
         extra_opts:
           - --strip-components=1
@@ -169,7 +190,7 @@
 
     - name: "Bitcoind | Install binaries into '/usr/local/bin/*'"
       ansible.builtin.copy:
-        src: "{{ _bitcoind_staging.path }}/bitcoin-core-{{ bitcoind_version }}/bin/"
+        src: "{{ _bitcoind_staging.path }}/bitcoin-{{ bitcoind_version }}/bin/"
         dest: /usr/local/bin/
         remote_src: true
         owner: root

--- a/templates/bitcoind.service.j2
+++ b/templates/bitcoind.service.j2
@@ -11,8 +11,8 @@
 # config file.
 
 [Unit]
-Description=Bitcoin Core daemon for network {{ bitcoind_network | capitalize }}
-Documentation=https://github.com/bitcoin/bitcoin/blob/master/doc/init.md
+Description=Bitcoin {{ 'Knots' if bitcoind_implementation == 'knots' else 'Core' }} daemon for network {{ bitcoind_network | capitalize }}
+Documentation={{ 'https://github.com/bitcoinknots/bitcoin/blob/master/doc/init.md' if bitcoind_implementation == 'knots' else 'https://github.com/bitcoin/bitcoin/blob/master/doc/init.md' }}
 
 # https://www.freedesktop.org/wiki/Software/systemd/NetworkTarget/
 After=network-online.target


### PR DESCRIPTION
## Summary 
- Add `bitcoind_implementation` toggle (`core` | `knots`) so the role can deploy either Bitcoin Core or Bitcoin Knots
- All implementation differences (download URLs, guix.sigs repo, GPG builder keys) are resolved into derived facts once at the top of the play
- CI now tests both Core (ubuntu2004 + ubuntu2204) and Knots (ubuntu2204) via the molecule matrix
- Version cookie comparison simplified from semver regex to string equality, fixing compatibility with Knots version strings like `29.2.knots20251110`

## Breaking changes
`bitcoind_pgp_builders_pub_key` has been removed and replaced by `bitcoind_pgp_builders_pub_key_core` / `bitcoind_pgp_builders_pub_key_knots`. Users who
override GPG keys in their playbooks will need to rename the variable.