### PR TITLE
Harden defaults, clean up config template, and extend tests

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
 
       - name: galaxy
         uses: robertdebock/galaxy-action@1.2.1

--- a/README.md
+++ b/README.md
@@ -92,28 +92,59 @@ To configure the Bitcoin node, you can use the following variables:
 > Use [rpcauth.py](https://raw.githubusercontent.com/bitcoin/bitcoin/master/share/rpcauth/rpcauth.py) to
 > generate `rpcauth` credentials.
 
-| Name                          | Value           | Note                                                 |
-| ----------------------------- | --------------- | ---------------------------------------------------- |
-| `bitcoind_data_dir`           | `/data/bitcoin` |                                                      |
+| Name                          | Value           | Note                                                  |
+| ----------------------------- | --------------- | ----------------------------------------------------- |
+| `bitcoind_data_dir`           | `/data/bitcoin` |                                                       |
 | `bitcoind_network`            | `main`          | Valid values are: `main`, `regtest`, `signet`, `test` |
-| `bitcoind_server`             | `true`          | Enable JSON-RPC server                               |
-| `bitcoind_disablewallet`      | `false`         | Disable wallet functionality                         |
-| `bitcoind_txindex`            | `true`          | Maintain full transaction index                      |
-| `bitcoind_listen`             | `true`          | Listen for incoming peer connections                 |
-| `bitcoind_whitelist`          | `127.0.0.1`    | Whitelist address (empty to disable)                 |
-| `bitcoind_rpc_auth`           |                 | Required. Generate with `rpcauth.py`                 |
-| `bitcoind_rpc_bind`           | `127.0.0.1`    | Address to expose the RPC server                     |
-| `bitcoind_rpc_port`           | `8332`          |                                                      |
-| `bitcoind_rpc_allow_ips`      | `[127.0.0.1]`  | IP or range like `10.0.0.0/24`                       |
-| `bitcoind_bind`               | `127.0.0.1`    |                                                      |
-| `bitcoind_enable_zmq`         | `true`          | Enable ZMQ pub/sub endpoints                         |
-| `bitcoind_zmq_host`           | `127.0.0.1`    |                                                      |
-| `bitcoind_zmq_port_rawblock`  | `28332`         |                                                      |
-| `bitcoind_zmq_port_rawtx`     | `28333`         |                                                      |
-| `bitcoind_zmq_port_hashblock` | `28332`         |                                                      |
-| `bitcoind_proxy`              |                 | SOCKS5 proxy (e.g. `127.0.0.1:9050` for Tor)        |
-| `bitcoind_use_onion`          | `false`         | Restrict to onion network only                       |
-| `bitcoind_nodes`              | `[]`            | Peers to add via `addnode=`                          |
+| `bitcoind_server`             | `true`          | Enable JSON-RPC server                                |
+| `bitcoind_disablewallet`      | `true`          | Disable wallet (enable only if needed)                |
+| `bitcoind_txindex`            | `true`          | Maintain full transaction index                       |
+| `bitcoind_listen`             | `true`          | Listen for incoming peer connections                  |
+| `bitcoind_whitelist`          | `127.0.0.1`     | Whitelist address (empty to disable)                  |
+| `bitcoind_rpc_auth`           |                 | Required. Generate with `rpcauth.py`                  |
+| `bitcoind_rpc_bind`           | `127.0.0.1`     | Address to expose the RPC server                      |
+| `bitcoind_rpc_port`           | `8332`          |                                                       |
+| `bitcoind_rpc_allow_ips`      | `[127.0.0.1]`   | IP or range like `10.0.0.0/24`                        |
+| `bitcoind_bind`               | `127.0.0.1`     |                                                       |
+| `bitcoind_enable_zmq`         | `false`         | Enable ZMQ pub/sub endpoints                          |
+| `bitcoind_zmq_host`           | `127.0.0.1`     |                                                       |
+| `bitcoind_zmq_port_rawblock`  | `28332`         |                                                       |
+| `bitcoind_zmq_port_rawtx`     | `28333`         |                                                       |
+| `bitcoind_zmq_port_hashblock` | `28332`         |                                                       |
+| `bitcoind_proxy`              |                 | SOCKS5 proxy (e.g. `127.0.0.1:9050` for Tor)          |
+| `bitcoind_use_onion`          | `false`         | Restrict to onion network only                        |
+| `bitcoind_nodes`              | `[]`            | Peers to add via `addnode=`                           |
+
+### Use-case examples
+
+The defaults provide a minimal-surface full node. Enable additional features as needed:
+
+**Lightning node (LND / CLN)**
+
+```yaml
+bitcoind_enable_zmq: true
+bitcoind_txindex: false  # not needed for Lightning
+```
+
+**Block explorer / Electrum server (Electrs / Fulcrum / mempool.space)**
+
+```yaml
+bitcoind_enable_zmq: true  # required for real-time block notifications
+bitcoind_txindex: true     # required for address lookups
+```
+
+**Tor-only (requires a running Tor daemon)**
+
+```yaml
+bitcoind_proxy: "127.0.0.1:9050"
+bitcoind_use_onion: true
+```
+
+**On-node wallet**
+
+```yaml
+bitcoind_disablewallet: false
+```
 
 ### GPG verification
 

--- a/README.md
+++ b/README.md
@@ -10,8 +10,8 @@ it uses sane defaults and some hardening measures for the Systemd service.
 - Sets up user, if not single user system
 - Downloads bitcoin binaries and verifies GPG signatures
 - Installs all shipped binaries to `/usr/local/bin` (i.e. `bitcoin-cli`, `bitcoind`, ...)
-- Sets up a systemd service with configuration at `/etc/bitcoind/<network>/bitcoind.conf`
-- Links `/home/<user>/.bitcoin` to `/etc/bitcoind/<network>`
+- Sets up a systemd service with configuration at `<data_dir>/bitcoind.conf`
+- Links `/home/<user>/.bitcoin` to `<data_dir>`
 
 ## Requirements
 
@@ -92,20 +92,19 @@ To configure the Bitcoin node, you can use the following variables:
 > Use [rpcauth.py](https://raw.githubusercontent.com/bitcoin/bitcoin/master/share/rpcauth/rpcauth.py) to
 > generate `rpcauth` credentials.
 
-| Name                     | Value                      | Note                                                 |
-| ------------------------ | -------------------------- | ---------------------------------------------------- |
-| `bitcoind_data_dir`      | `/data/bitcoin`            |                                                      |
-| `bitcoind_network`       | `main`                     | Valid values are: `regtest`, `signet` and `test`     |
-| `bitcoind_rpc_auth`      | `bitcoin:2e00...`          | Prevent your password from being stored as cleartext |
-| `bitcoind_rpc_user`      | `bitcoin`                  | If possible use `btc_rpc_auth` instead               |
-| `bitcoind_rpc_password`  | `bitcoin`                  | If possible use `btc_rpc_auth` instead               |
-| `bitcoind_zmq_host`      | `127.0.0.1`                |                                                      |
-| `bitcoind_bind`          | `127.0.0.1`                |                                                      |
-| `bitcoind_rpc_bind`      | `127.0.0.1`                | This is where to expose the RPC server               |
-| `bitcoind_rpc_allow_ips` | `[127.0.0.1]`              | This can be an IP or a range like `10.0.0.0/24`      |
-| `bitcoind_use_onion`     | `False`                    | This enables onion support                           |
-| `bitcoind_onion_proxy`   | `127.0.0.1:9050`           |                                                      |
-| `bitcoind_onion_nodes`   | `['tsr2f2....onion:8333']` |                                                      |
+| Name                     | Value              | Note                                                 |
+| ------------------------ | ------------------ | ---------------------------------------------------- |
+| `bitcoind_data_dir`      | `/data/bitcoin`    |                                                      |
+| `bitcoind_network`       | `main`             | Valid values are: `main`, `regtest`, `signet`, `test` |
+| `bitcoind_rpc_auth`      |                    | Required. Generate with `rpcauth.py`                 |
+| `bitcoind_rpc_bind`      | `127.0.0.1`        | Address to expose the RPC server                     |
+| `bitcoind_rpc_port`      | `8332`             |                                                      |
+| `bitcoind_rpc_allow_ips` | `[127.0.0.1]`      | IP or range like `10.0.0.0/24`                       |
+| `bitcoind_bind`          | `127.0.0.1`        |                                                      |
+| `bitcoind_zmq_host`      | `127.0.0.1`        |                                                      |
+| `bitcoind_proxy`         | `127.0.0.1:9050`   | SOCKS5 proxy (e.g. Tor)                              |
+| `bitcoind_use_onion`     | `false`            | Restrict to onion network only                       |
+| `bitcoind_nodes`         | `[]`               | Peers to add via `addnode=`                          |
 
 ### GPG verification
 

--- a/README.md
+++ b/README.md
@@ -83,28 +83,37 @@ Bitcoin node are the following ones:
 | `bitcoind_version`        | `30.2`             | Knots example: `29.2.knots20251110`     |
 | `bitcoind_user`           | `bitcoin`          |                                         |
 | `bitcoind_group`          | `bitcoin`          |                                         |
-| `bitcoind_arch`           | `x86_64-linux-gnu` | Use `aarch64-linux-gnu` for Raspberry Pi|
+| `bitcoind_arch`           | _(auto-detected)_  | Override for cross-platform deploys     |
 
-> If you want to install Bitcoin into a Raspberry you need to change the architecture to `aarch64-linux-gnu`.
+> Architecture is auto-detected from `ansible_architecture`. Override with e.g. `aarch64-linux-gnu` for Raspberry Pi.
 
 To configure the Bitcoin node, you can use the following variables:
 
 > Use [rpcauth.py](https://raw.githubusercontent.com/bitcoin/bitcoin/master/share/rpcauth/rpcauth.py) to
 > generate `rpcauth` credentials.
 
-| Name                     | Value              | Note                                                 |
-| ------------------------ | ------------------ | ---------------------------------------------------- |
-| `bitcoind_data_dir`      | `/data/bitcoin`    |                                                      |
-| `bitcoind_network`       | `main`             | Valid values are: `main`, `regtest`, `signet`, `test` |
-| `bitcoind_rpc_auth`      |                    | Required. Generate with `rpcauth.py`                 |
-| `bitcoind_rpc_bind`      | `127.0.0.1`        | Address to expose the RPC server                     |
-| `bitcoind_rpc_port`      | `8332`             |                                                      |
-| `bitcoind_rpc_allow_ips` | `[127.0.0.1]`      | IP or range like `10.0.0.0/24`                       |
-| `bitcoind_bind`          | `127.0.0.1`        |                                                      |
-| `bitcoind_zmq_host`      | `127.0.0.1`        |                                                      |
-| `bitcoind_proxy`         | `127.0.0.1:9050`   | SOCKS5 proxy (e.g. Tor)                              |
-| `bitcoind_use_onion`     | `false`            | Restrict to onion network only                       |
-| `bitcoind_nodes`         | `[]`               | Peers to add via `addnode=`                          |
+| Name                          | Value           | Note                                                 |
+| ----------------------------- | --------------- | ---------------------------------------------------- |
+| `bitcoind_data_dir`           | `/data/bitcoin` |                                                      |
+| `bitcoind_network`            | `main`          | Valid values are: `main`, `regtest`, `signet`, `test` |
+| `bitcoind_server`             | `true`          | Enable JSON-RPC server                               |
+| `bitcoind_disablewallet`      | `false`         | Disable wallet functionality                         |
+| `bitcoind_txindex`            | `true`          | Maintain full transaction index                      |
+| `bitcoind_listen`             | `true`          | Listen for incoming peer connections                 |
+| `bitcoind_whitelist`          | `127.0.0.1`    | Whitelist address (empty to disable)                 |
+| `bitcoind_rpc_auth`           |                 | Required. Generate with `rpcauth.py`                 |
+| `bitcoind_rpc_bind`           | `127.0.0.1`    | Address to expose the RPC server                     |
+| `bitcoind_rpc_port`           | `8332`          |                                                      |
+| `bitcoind_rpc_allow_ips`      | `[127.0.0.1]`  | IP or range like `10.0.0.0/24`                       |
+| `bitcoind_bind`               | `127.0.0.1`    |                                                      |
+| `bitcoind_enable_zmq`         | `true`          | Enable ZMQ pub/sub endpoints                         |
+| `bitcoind_zmq_host`           | `127.0.0.1`    |                                                      |
+| `bitcoind_zmq_port_rawblock`  | `28332`         |                                                      |
+| `bitcoind_zmq_port_rawtx`     | `28333`         |                                                      |
+| `bitcoind_zmq_port_hashblock` | `28332`         |                                                      |
+| `bitcoind_proxy`              |                 | SOCKS5 proxy (e.g. `127.0.0.1:9050` for Tor)        |
+| `bitcoind_use_onion`          | `false`         | Restrict to onion network only                       |
+| `bitcoind_nodes`              | `[]`            | Peers to add via `addnode=`                          |
 
 ### GPG verification
 

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -9,13 +9,24 @@ bitcoind_implementation: core
 # Bitcoin binary information
 # Core default: 30.2  |  Knots example: 29.2.knots20251110
 bitcoind_version: 30.2
-bitcoind_arch: x86_64-linux-gnu
+# Auto-detected from ansible_architecture when empty.
+# Override for cross-platform deploys (e.g. "aarch64-linux-gnu").
+bitcoind_arch: ""
 
-# Serve JOSN-RPC
+# Serve JSON-RPC
 bitcoind_server: true
 
 # Wallet
 bitcoind_disablewallet: false
+
+# Transaction index (increases disk usage significantly)
+bitcoind_txindex: true
+
+# Listen for incoming peer connections
+bitcoind_listen: true
+
+# Whitelist localhost connections
+bitcoind_whitelist: 127.0.0.1
 
 # Bitcoin GPG public keys per implementation.
 # Names must match the ones found in the respective guix.sigs repositories:
@@ -56,16 +67,19 @@ bitcoind_rpc_port: 8332
 bitcoind_rpc_allow_ips:
   - 127.0.0.1
 
-# This is the host where you want to expose the ZMQ TCP socket
-# to receive raw block and transaction updates.
+# ZMQ pub/sub endpoints for raw blocks and transactions.
+# Set to false to disable ZMQ entirely.
+bitcoind_enable_zmq: true
 bitcoind_zmq_host: 127.0.0.1
+bitcoind_zmq_port_rawblock: 28332
+bitcoind_zmq_port_rawtx: 28333
+bitcoind_zmq_port_hashblock: 28332
 
-bitcoind_proxy: 127.0.0.1:9050
+# SOCKS5 proxy (e.g. Tor). Empty string disables.
+bitcoind_proxy: ""
 
+# Peer nodes to add via addnode=
 bitcoind_nodes: []
-  # For clearnet, see: https://bitnodes.io/nodes/?q=Tor%20network
-  # - 82.101.236.91:8333
-  # For Tor, see: https://bitnodes.io/nodes/?q=Tor%20network
-  # - tsr2f2pjzvkjn32gt6dnfjzmgbbq6kjj62d3jgedwx4qr2ku3tb7pvqd.onion:8333
 
+# Restrict to onion network only (requires bitcoind_proxy pointing at Tor)
 bitcoind_use_onion: false

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -16,8 +16,8 @@ bitcoind_arch: ""
 # Serve JSON-RPC
 bitcoind_server: true
 
-# Wallet
-bitcoind_disablewallet: false
+# Wallet (disabled by default — enable only if you need on-node wallet functionality)
+bitcoind_disablewallet: true
 
 # Transaction index (increases disk usage significantly)
 bitcoind_txindex: true
@@ -68,8 +68,8 @@ bitcoind_rpc_allow_ips:
   - 127.0.0.1
 
 # ZMQ pub/sub endpoints for raw blocks and transactions.
-# Set to false to disable ZMQ entirely.
-bitcoind_enable_zmq: true
+# Disabled by default — enable if you have ZMQ subscribers (e.g. Lightning, mempool).
+bitcoind_enable_zmq: false
 bitcoind_zmq_host: 127.0.0.1
 bitcoind_zmq_port_rawblock: 28332
 bitcoind_zmq_port_rawtx: 28333

--- a/handlers/main.yml
+++ b/handlers/main.yml
@@ -2,4 +2,5 @@
 - name: Bitcoind | Ensure bitcoind systemd unit is restarted
   ansible.builtin.systemd:
     name: bitcoind-{{ bitcoind_network }}.service
+    daemon_reload: true
     state: restarted

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -1,9 +1,9 @@
 galaxy_info:
   author: mvrahden
-  description: Bitcoin Core client as a Systemd service
+  description: Bitcoin Core / Knots client as a Systemd service
   role_name: bitcoind
   license: MIT
-  min_ansible_version: "2.9"
+  min_ansible_version: "2.16"
 
   # Provide a list of supported platforms, and for each platform a list of versions.
   # If you don't wish to enumerate all versions for a particular platform, use 'all'.
@@ -19,4 +19,5 @@ galaxy_info:
   galaxy_tags:
     - bitcoin
     - bitcoin-core
+    - bitcoin-knots
     - bitcoind

--- a/molecule/default/verify.yml
+++ b/molecule/default/verify.yml
@@ -6,6 +6,10 @@
   vars:
     bitcoind_implementation: "{{ lookup('env', 'BITCOIND_IMPL') | default('core', true) }}"
     bitcoind_version: "{{ lookup('env', 'BITCOIND_VERSION') | default('30.2', true) }}"
+    bitcoind_data_dir: /data/bitcoin
+    bitcoind_user: bitcoin
+    bitcoind_group: bitcoin
+    bitcoind_network: regtest
     # Core 30.x: bitcoin wrapper replaces test_bitcoin
     # Knots 29.x: still has test_bitcoin, no bitcoin wrapper
     _core_binaries:
@@ -41,3 +45,65 @@
           - item.stat.gr_name == 'root'
           - item.stat.mode == '0755'
       with_items: "{{ bitcoind_bins.results }}"
+
+    - name: "Check systemd service is running"
+      ansible.builtin.systemd:
+        name: "bitcoind-{{ bitcoind_network }}.service"
+      register: _service_state
+
+    - name: "Test that systemd service is active"
+      ansible.builtin.assert:
+        that:
+          - _service_state.status.ActiveState == 'active'
+          - _service_state.status.SubState == 'running'
+
+    - name: "Check config file"
+      ansible.builtin.stat:
+        path: "{{ bitcoind_data_dir }}/bitcoind.conf"
+      register: _config_stat
+
+    - name: "Test config file permissions"
+      ansible.builtin.assert:
+        that:
+          - _config_stat.stat.exists
+          - _config_stat.stat.pw_name == bitcoind_user
+          - _config_stat.stat.gr_name == bitcoind_group
+          - _config_stat.stat.mode == '0640'
+
+    - name: "Check data directory"
+      ansible.builtin.stat:
+        path: "{{ bitcoind_data_dir }}"
+      register: _data_dir_stat
+
+    - name: "Test data directory permissions"
+      ansible.builtin.assert:
+        that:
+          - _data_dir_stat.stat.exists
+          - _data_dir_stat.stat.isdir
+          - _data_dir_stat.stat.pw_name == bitcoind_user
+          - _data_dir_stat.stat.gr_name == bitcoind_group
+          - _data_dir_stat.stat.mode == '0750'
+
+    - name: "Check version cookie file"
+      ansible.builtin.stat:
+        path: "{{ bitcoind_data_dir }}/.bitcoind.version"
+      register: _cookie_stat
+
+    - name: "Test version cookie file exists"
+      ansible.builtin.assert:
+        that:
+          - _cookie_stat.stat.exists
+          - _cookie_stat.stat.pw_name == bitcoind_user
+          - _cookie_stat.stat.gr_name == bitcoind_group
+
+    - name: "Check symlink"
+      ansible.builtin.stat:
+        path: "/home/{{ bitcoind_user }}/.bitcoin"
+      register: _symlink_stat
+
+    - name: "Test symlink points to data directory"
+      ansible.builtin.assert:
+        that:
+          - _symlink_stat.stat.exists
+          - _symlink_stat.stat.islnk
+          - _symlink_stat.stat.lnk_target == bitcoind_data_dir

--- a/tasks/gpg.yml
+++ b/tasks/gpg.yml
@@ -17,6 +17,9 @@
     cmd: gpg --homedir {{ _bitcoind_gpg_home }} --recv-keys {{ gpg_id }}
   register: _gpg_key_import
   changed_when: "'imported' in _gpg_key_import.stderr"
+  retries: 3
+  delay: 5
+  until: _gpg_key_import.rc == 0
   when: _gpg_key_check.rc != 0
 
 - name: "Bitcoind | Ensure attestation directory for '{{ gpg_user }}' exists"
@@ -29,7 +32,7 @@
   ansible.builtin.get_url:
     url: "{{ _bitcoind_guix_sigs_base_url }}/{{ bitcoind_version }}/{{ gpg_user }}/all.SHA256SUMS.asc"
     dest: "{{ _bitcoind_staging.path }}/attestations/{{ gpg_user }}/all.SHA256SUMS.asc"
-    http_agent: yourbtc-ansible
+    http_agent: bitcoind-ansible
 
 - name: "Bitcoind | Verify GPG signature for '{{ gpg_user }}' (Bitcoin v{{ bitcoind_version }})"
   ansible.builtin.command:

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -51,7 +51,9 @@
   with_items:
     - gpg
     - dirmngr
-  when: _bitcoind_pgp_builders | length > 0
+  when:
+    - _bitcoind_pgp_builders | length > 0
+    - not (bitcoind_skip_gpg_verification | default(false) | bool)
 
 - name: "Bitcoind | Ensure group '{{ bitcoind_group }}' exists"
   ansible.builtin.group:
@@ -146,7 +148,9 @@
         gpg_user: "{{ item.name }}"
         gpg_id: "{{ item.id }}"
       with_items: "{{ _bitcoind_pgp_builders }}"
-      when: _bitcoind_pgp_builders | length > 0
+      when:
+        - _bitcoind_pgp_builders | length > 0
+        - not (bitcoind_skip_gpg_verification | default(false) | bool)
 
     # Fix #1: Extract checksum from the GPG-verified SHA256SUMS (not a fresh HTTP fetch)
     - name: "Bitcoind | Extract verified checksum for bitcoin-{{ bitcoind_version }}-{{ bitcoind_arch }}.tar.gz"
@@ -248,6 +252,7 @@
     daemon_reload: true
     enabled: true
     state: started
+  register: _bitcoind_service_start
 
 - name: "Bitcoind | Ensure version cookie file set"
   ansible.builtin.template:
@@ -256,3 +261,4 @@
     owner: "{{ bitcoind_user }}"
     group: "{{ bitcoind_group }}"
     mode: "0644"
+  when: _bitcoind_service_start is not failed

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -3,6 +3,13 @@
   ansible.builtin.set_fact:
     _bitcoind_change_version: false # default
 
+- name: Bitcoind | Auto-detect architecture
+  ansible.builtin.set_fact:
+    bitcoind_arch: >-
+      {{ 'aarch64-linux-gnu' if ansible_architecture == 'aarch64'
+         else 'x86_64-linux-gnu' }}
+  when: bitcoind_arch | length == 0
+
 - name: Bitcoind | Validate implementation is supported
   ansible.builtin.fail:
     msg: >-
@@ -94,18 +101,18 @@
     mode: "0750"
 
 - name: "Bitcoind | Load version cookie file"
-  slurp:
+  ansible.builtin.slurp:
     src: "{{ bitcoind_data_dir }}/.bitcoind.version"
   register: _bitcoind_version_cookie_file
   ignore_errors: true
 
 - name: "Bitcoind | Determine version change from version cookie vs. configured version"
-  set_fact:
+  ansible.builtin.set_fact:
     _bitcoind_change_version: "{{ (_bitcoind_version_cookie_file['content'] | b64decode | trim | split('\n') | last) != (bitcoind_version | string) }}"
   when: "not _bitcoind_version_cookie_file.failed"
 
 - name: "Bitcoind | Debug detected version change from cookie"
-  debug:
+  ansible.builtin.debug:
     msg: "{{ _bitcoind_change_version }}"
 
 # ── Download, verify, and install Bitcoin (only on first install or version change) ──
@@ -140,7 +147,7 @@
       ansible.builtin.get_url:
         url: "{{ _bitcoind_base_url }}/SHA256SUMS"
         dest: "{{ _bitcoind_staging.path }}/SHA256SUMS"
-        http_agent: yourbtc-ansible
+        http_agent: bitcoind-ansible
 
     - name: "Bitcoind | Verify signature with given keys"
       ansible.builtin.include_tasks: gpg.yml
@@ -167,7 +174,7 @@
         url: "{{ _bitcoind_base_url }}/bitcoin-{{ bitcoind_version }}-{{ bitcoind_arch }}.tar.gz"
         dest: "{{ _bitcoind_staging.path }}/bitcoin-{{ bitcoind_version }}-{{ bitcoind_arch }}.tar.gz"
         checksum: "sha256:{{ _bitcoind_verified_checksum.stdout }}"
-        http_agent: yourbtc-ansible
+        http_agent: bitcoind-ansible
 
     - name: "Bitcoind | Ensure extraction directory exists"
       ansible.builtin.file:

--- a/templates/bitcoin.conf.j2
+++ b/templates/bitcoin.conf.j2
@@ -10,29 +10,15 @@
 # addnode, connect, port, bind, rpcport, rpcbind or wallet, you will also
 # want to read "[Sections]" further down.
 
-# Run on the testnet network
-#testnet=0
-
-# Run on a signet network
-#signet=0
-
-# Run a regression test network
-#regtest=0
-
 # Connect via a SOCKS5 proxy
-#proxy=127.0.0.1:9050
 {% if bitcoind_proxy %}
 proxy={{ bitcoind_proxy }}
 {% endif %}
 
 # Bind to given address and always listen on it. Use [host]:port notation for IPv6
-#bind=<addr>
 {% if bitcoind_network == "main" %}
 bind={{ bitcoind_bind }}
 {% endif %}
-
-# Bind to given address and add permission flags to peers connecting to it. Use [host]:port notation for IPv6
-#whitebind=perm@<addr>
 
 ##############################################################
 ##            Quick Primer on addnode vs connect            ##
@@ -58,27 +44,17 @@ bind={{ bitcoind_bind }}
 ##############################################################
 
 # Use as many addnode= settings as you like to connect to specific peers
-#addnode=69.164.218.197
-#addnode=10.0.0.2:8333
 {% if bitcoind_network == "main" %}
 {% for item in bitcoind_nodes %}
 addnode={{ item }}
 {% endfor %}
 {% endif %}
 
-# Alternatively use as many connect= settings as you like to connect ONLY to specific peers
-#connect=69.164.218.197
-#connect=10.0.0.1:8333
-{% if bitcoind_network == "main" %}
-{% endif %}
-
-# Listening mode, enabled by default except when 'connect' is being used
-#listen=1
+# Listening mode
+{% if bitcoind_listen %}
 listen=1
-
-# Port on which to listen for connections (default: 8333, testnet: 18333, signet: 38333, regtest: 18444)
-#port=
-{% if bitcoind_network == "main" %}
+{% else %}
+listen=0
 {% endif %}
 
 # Maximum number of inbound + outbound connections (default: 125). This option
@@ -100,14 +76,11 @@ listen=1
 #
 
 # server=1 tells Bitcoin-Qt and bitcoind to accept JSON-RPC commands
-#server=0
 {% if bitcoind_server %}
 server=1
 {% endif %}
 
 # Bind to given address to listen for JSON-RPC connections.
-# Refer to the manpage or bitcoind -help for further details.
-#rpcbind=<addr>
 {% if bitcoind_network == "main" %}
 rpcbind={{ bitcoind_rpc_bind }}
 {% endif %}
@@ -115,8 +88,6 @@ rpcbind={{ bitcoind_rpc_bind }}
 # If no rpcpassword is set, rpc cookie auth is sought. The default `-rpccookiefile` name
 # is .cookie and found in the `-datadir` being used for bitcoind. This option is typically used
 # when the server and client are run as the same user.
-#
-# If not, you must set rpcuser and rpcpassword to secure the JSON-RPC API.
 #
 # The config option `rpcauth` can be added to server startup argument. It is set at initialization time
 # using the output from the script in share/rpcauth/rpcauth.py after providing a username:
@@ -135,54 +106,19 @@ rpcbind={{ bitcoind_rpc_bind }}
 # rpcauth=bob:b2dd077cb54591a2f3139e69a897ac$4e71f08d48b4347cf8eff3815c0e25ae2e9a4340474079f55705f40574f4ec99
 rpcauth={{ bitcoind_rpc_auth }}
 
-# How many seconds bitcoin will wait for a complete RPC HTTP request.
-# after the HTTP connection is established.
-#rpcclienttimeout=30
-
 # By default, only RPC connections from localhost are allowed.
 # Specify as many rpcallowip= settings as you like to allow connections from other hosts,
 # either as a single IPv4/IPv6 or with a subnet specification.
-
-# NOTE: opening up the RPC port to hosts outside your local trusted network is NOT RECOMMENDED,
-# because the rpcpassword is transmitted over the network unencrypted.
-
-# server=1 tells Bitcoin-Qt to accept JSON-RPC commands.
-# it is also read by bitcoind to determine if RPC should be enabled
-#rpcallowip=10.1.1.34/255.255.255.0
-#rpcallowip=1.2.3.4/24
-#rpcallowip=2001:db8:85a3:0:0:8a2e:370:7334/96
 {% for item in bitcoind_rpc_allow_ips %}
 rpcallowip={{ item }}
 {% endfor %}
 
 # Listen for RPC connections on this TCP port:
-#rpcport=8332
 {% if bitcoind_network == "main" %}
 rpcport={{ bitcoind_rpc_port }}
 {% endif %}
 
-# You can use Bitcoin or bitcoind to send commands to Bitcoin/bitcoind
-# running on another host using this option:
-#rpcconnect=127.0.0.1
-
-# Wallet options
-
-# Specify where to find wallet, lockfile and logs. If not present, those files will be
-# created as new.
-#wallet=</path/to/dir>
-
-# Create transactions that have enough fees so they are likely to begin confirmation within n blocks (default: 6).
-# This setting is over-ridden by the -paytxfee option.
-#txconfirmtarget=n
-
-# Pay a transaction fee every time you send bitcoins.
-#paytxfee=0.000x
-
 # Miscellaneous options
-
-# Pre-generate this many public/private key pairs, so wallet backups will be valid for
-# both prior transactions and several dozen future transactions.
-#keypool=100
 
 # Maintain coinstats index used by the gettxoutsetinfo RPC (default: 0).
 #coinstatsindex=1
@@ -194,14 +130,6 @@ rpcport={{ bitcoind_rpc_port }}
 # >=550 = target to stay under in MiB.
 #prune=550
 
-# User interface options
-
-# Start Bitcoin minimized
-#min=1
-
-# Minimize to the system tray
-#minimizetotray=1
-
 # Misc/Undocumented Settings
 chain={{ bitcoind_network }}
 pid=/run/bitcoind/{{ bitcoind_network }}/bitcoind.pid
@@ -211,16 +139,19 @@ datadir={{ bitcoind_data_dir }}
 onlynet=onion
 {% endif %}
 
-daemon=1
-txindex=1
+txindex={{ 1 if bitcoind_txindex else 0 }}
 
-whitelist=127.0.0.1
+{% if bitcoind_whitelist %}
+whitelist={{ bitcoind_whitelist }}
+{% endif %}
 
 disablewallet={{ 1 if bitcoind_disablewallet else 0 }}
 
-zmqpubrawblock=tcp://{{ bitcoind_zmq_host }}:28332
-zmqpubrawtx=tcp://{{ bitcoind_zmq_host }}:28333
-zmqpubhashblock=tcp://{{ bitcoind_zmq_host }}:28332
+{% if bitcoind_enable_zmq %}
+zmqpubrawblock=tcp://{{ bitcoind_zmq_host }}:{{ bitcoind_zmq_port_rawblock }}
+zmqpubrawtx=tcp://{{ bitcoind_zmq_host }}:{{ bitcoind_zmq_port_rawtx }}
+zmqpubhashblock=tcp://{{ bitcoind_zmq_host }}:{{ bitcoind_zmq_port_hashblock }}
+{% endif %}
 
 
 # [Sections]
@@ -234,42 +165,33 @@ zmqpubhashblock=tcp://{{ bitcoind_zmq_host }}:28332
 #[main]
 
 # Options only for testnet
-#[test]
 {% if bitcoind_network == "test" %}
 [{{ bitcoind_network }}]
 {% for item in bitcoind_nodes %}
 addnode={{ item }}
 {% endfor %}
-#connect=10.0.0.1:8333
-#port=
 bind={{ bitcoind_bind }}
 rpcport={{ bitcoind_rpc_port }}
 rpcbind={{ bitcoind_rpc_bind }}
 {% endif %}
 
 # Options only for signet
-#[signet]
 {% if bitcoind_network == "signet" %}
 [{{ bitcoind_network }}]
 {% for item in bitcoind_nodes %}
 addnode={{ item }}
 {% endfor %}
-#connect=10.0.0.1:8333
-#port=
 bind={{ bitcoind_bind }}
 rpcport={{ bitcoind_rpc_port }}
 rpcbind={{ bitcoind_rpc_bind }}
 {% endif %}
 
 # Options only for regtest
-#[regtest]
 {% if bitcoind_network == "regtest" %}
 [{{ bitcoind_network }}]
 {% for item in bitcoind_nodes %}
 addnode={{ item }}
 {% endfor %}
-#connect=10.0.0.1:8333
-#port=
 bind={{ bitcoind_bind }}
 rpcport={{ bitcoind_rpc_port }}
 rpcbind={{ bitcoind_rpc_bind }}

--- a/templates/bitcoind.service.j2
+++ b/templates/bitcoind.service.j2
@@ -47,10 +47,6 @@ Group={{ bitcoind_group }}
 RuntimeDirectory=bitcoind/{{ bitcoind_network }}
 RuntimeDirectoryMode=0710
 
-# /var/lib/bitcoind
-StateDirectory=bitcoind
-StateDirectoryMode=0710
-
 # Hardening measures
 ####################
 
@@ -93,6 +89,9 @@ ProtectClock=true
 
 # Drop all capabilities (bitcoind needs none as non-root)
 CapabilityBoundingSet=
+
+# Allow enough file descriptors for peers + LevelDB
+LimitNOFILE=32768
 
 [Install]
 WantedBy=multi-user.target


### PR DESCRIPTION
- Reduce default attack surface: disable wallet and ZMQ by default (opt-in for stacks that need them)
- Parameterize previously hardcoded config values (txindex, listen, whitelist, ZMQ ports, proxy) as role
variables
- Auto-detect architecture from ansible_architecture
- Clean up bitcoin.conf template (remove dead code, commented-out boilerplate, redundant daemon=1)
- Remove unused StateDirectory from systemd unit, add LimitNOFILE=32768
- Fix handler missing daemon_reload, FQCN inconsistencies, http_agent typo
- Add GPG keyserver import retry logic
- Extend molecule verify playbook (service state, config permissions, data dir, cookie, symlink)
- Add use-case examples to README (Lightning, Electrum server, Tor, wallet)